### PR TITLE
Update SSH command to include job port

### DIFF
--- a/vscode-remote.sh
+++ b/vscode-remote.sh
@@ -131,7 +131,7 @@ function ssh_connect () {
     fi
 
     echo "Connecting to $NODE ($TYPE) via SSH"
-    ssh $NODE
+    ssh -p $JOB_PORT $NODE
 }
 
 function connect () {


### PR DESCRIPTION
The vscode-remote ssh command was not working because the port was missing.